### PR TITLE
Cache digests

### DIFF
--- a/lib/cache_digests.rb
+++ b/lib/cache_digests.rb
@@ -1,4 +1,5 @@
 require 'digest/md5'
+require 'cache_digests/cached_digests'
 require 'cache_digests/template_digestor'
 require 'cache_digests/fragment_helper'
 require 'cache_digests/engine' if defined?(Rails)

--- a/lib/cache_digests/cached_digests.rb
+++ b/lib/cache_digests/cached_digests.rb
@@ -1,0 +1,3 @@
+module CacheDigests
+  CACHED_DIGESTS = {}
+end

--- a/lib/cache_digests/engine.rb
+++ b/lib/cache_digests/engine.rb
@@ -6,9 +6,10 @@ module CacheDigests
       ActiveSupport.on_load :action_view do
         ActionView::Base.send :include, CacheDigests::FragmentHelper
       end
-      
+
       config.to_prepare do
         CacheDigests::TemplateDigestor.logger = Rails.logger
+        CACHED_DIGESTS.clear
       end
     end
   end

--- a/lib/cache_digests/fragment_helper.rb
+++ b/lib/cache_digests/fragment_helper.rb
@@ -4,7 +4,9 @@ module CacheDigests
       # Automatically include this template's digest -- and its childrens' -- in the cache key.
       def fragment_for(key, options = nil, &block)
         if !explicitly_versioned_cache_key?(key)
-          super [*key, TemplateDigestor.digest(@virtual_path, formats.last.to_sym, lookup_context)], options, &block
+          flat_key                   = ActiveSupport::Cache.expand_cache_key(key.is_a?(Hash) ? url_for(key).split("://").last : key, :views)
+          CACHED_DIGESTS[flat_key] ||= TemplateDigestor.digest(@virtual_path, formats.last.to_sym, lookup_context)
+          super [*key, CACHED_DIGESTS[flat_key]], options, &block
         else
           super
         end

--- a/lib/cache_digests/fragment_helper.rb
+++ b/lib/cache_digests/fragment_helper.rb
@@ -4,7 +4,8 @@ module CacheDigests
       # Automatically include this template's digest -- and its childrens' -- in the cache key.
       def fragment_for(key, options = nil, &block)
         if !explicitly_versioned_cache_key?(key)
-          flat_key                   = ActiveSupport::Cache.expand_cache_key(key.is_a?(Hash) ? url_for(key).split("://").last : key, :views)
+          key                        = url_for(key).split("://").last if key.is_a?(Hash)
+          flat_key                   = ActiveSupport::Cache.expand_cache_key(key, :views)
           CACHED_DIGESTS[flat_key] ||= TemplateDigestor.digest(@virtual_path, formats.last.to_sym, lookup_context)
           super [*key, CACHED_DIGESTS[flat_key]], options, &block
         else


### PR DESCRIPTION
Instead of generating the MD5 digest every time the view loads, we should cache the digests.

In order not to defy the meaning of this whole gem I used a constant that is cleared every time `config.to_prepare` is invoked. That way we don't loose any of the pain relief this offers while gaining a bit more performance.
