### PR TITLE
Fix digestion of templates with recursive dependencies

### DIFF
--- a/lib/cache_digests/template_digestor.rb
+++ b/lib/cache_digests/template_digestor.rb
@@ -28,7 +28,9 @@ module CacheDigests
     cattr_accessor(:logger, instance_reader: true)
 
     def self.digest(name, format, finder, options = {})
-      cache.fetch([ "digestor", cache_prefix, name, format ].compact.join("/")) do
+      cache_key = [ "digestor", cache_prefix, name, format ].compact.join("/")
+      cache.fetch(cache_key) do
+        cache.write(cache_key, nil) # Prevent re-entry
         new(name, format, finder, options).digest
       end
     end

--- a/test/fixtures/level/_recursion.html.erb
+++ b/test/fixtures/level/_recursion.html.erb
@@ -1,0 +1,1 @@
+<%= render "recursion" %>

--- a/test/fixtures/level/recursion.html.erb
+++ b/test/fixtures/level/recursion.html.erb
@@ -1,0 +1,1 @@
+<%= render "recursion" %>

--- a/test/template_digestor_test.rb
+++ b/test/template_digestor_test.rb
@@ -83,6 +83,10 @@ class TemplateDigestorTest < MiniTest::Unit::TestCase
     end
   end
   
+  def test_recursion_in_renders
+    assert digest("level/recursion")
+  end
+  
   def test_dont_generate_a_digest_for_missing_templates
     assert_equal '', digest("nothing/there")
   end


### PR DESCRIPTION
Computing the digest of a template that has recursive dependencies causes infinite recursion.

``` erb
<%# In self.html.erb %>
<% render 'self' %>
```

BOOM!

Solution I used it to put a placeholder in the cache until the digest is computed.
