### PR TITLE
Add skip_digest option key to allow bypassing cache digestion

### DIFF
--- a/lib/cache_digests/fragment_helper.rb
+++ b/lib/cache_digests/fragment_helper.rb
@@ -5,9 +5,16 @@ module CacheDigests
     end
 
     private
-      # Automatically include this template's digest -- and its childrens' -- in the cache key.
+      # Automatically include this template's digest -- and its childrens' --
+      # in the cache key. Cache digests can be skipped by either providing an
+      # explicitly versioned key (an Array-based key with the first key
+      # matching "v#" e.g. ['v3','my-key']) or by passing skip_digest: true to
+      # the options hash.
       def fragment_for(key, options = nil, &block)
-        if !explicitly_versioned_cache_key?(key)
+        skip_digest = explicitly_versioned_cache_key?(key) ||
+          (options && options.delete(:skip_digest))
+
+        if !skip_digest
           super fragment_name_with_digest(key), options, &block
         else
           super

--- a/test/fragment_helper_test.rb
+++ b/test/fragment_helper_test.rb
@@ -9,6 +9,25 @@ class Fragmenter
   end
 end
 
+class BaseFragmenter
+  attr_accessor :virtual_path, :formats, :lookup_context
+  def initialize
+    @virtual_path = ''
+    @formats = [:html]
+  end
+
+  private
+    # Give a base implementation of fragment_for so super calls from
+    # ChildFragmenter have a method to delegate to.
+    def fragment_for(key,opts=nil,&blk)
+      key
+    end
+end
+
+class ChildFragmenter < BaseFragmenter
+  include CacheDigests::FragmentHelper
+end
+
 class FragmentHelperTest < MiniTest::Unit::TestCase
   def setup
     # would love some mocha here
@@ -46,8 +65,28 @@ class FragmentHelperTest < MiniTest::Unit::TestCase
     assert_equal ['key1', 'key2', 'digest'], key_with_digest
   end
 
+  def test_digest_skipped_when_opted_out
+    key = child_fragmenter.send(:fragment_for, 'key1', {skip_digest: true})
+    # 'key1' key derived from super call to BaseFragmenter above
+    assert_equal 'key1', key
+  end
+
+  def test_digest_skipped_when_v_number_keyed
+    key = child_fragmenter.send(:fragment_for, ['v1','key1'])
+    assert_equal ['v1','key1'], key
+  end
+
+  def test_digest_not_skipped_otherwise
+    key_with_digest = child_fragmenter.send(:fragment_for, 'key1', {skip_digest: false})
+    assert_equal ['key1','digest'], key_with_digest
+  end
+
   private
   def fragmenter
     @fragmenter ||= Fragmenter.new
+  end
+
+  def child_fragmenter
+    @child_fragmenter ||= ChildFragmenter.new
   end
 end


### PR DESCRIPTION
In addition to the already present bypass method of passing an explicitly version numbered cache key (e.g. ['v1','cache-key']), this adds an option to the cache in order to give control in bypassing the digest append step on a case-by-case basis.

Discussion in #12.
