### PR TITLE
Match non-whitespace characters instead of non-space characters

### DIFF
--- a/lib/cache_digests/template_digestor.rb
+++ b/lib/cache_digests/template_digestor.rb
@@ -4,7 +4,7 @@ require 'logger'
 
 module CacheDigests
   class TemplateDigestor
-    EXPLICIT_DEPENDENCY = /# Template Dependency: ([^ ]+)/
+    EXPLICIT_DEPENDENCY = /# Template Dependency: (\S+)/
 
     # Matches:
     #   render partial: "comments/comment", collection: commentable.comments


### PR DESCRIPTION
This change fixes an issue with HAML (#8), but it works equally well with ERB. When parsing this line of HAML:

```
-# Template Dependency: things/_thing
```

The old pattern would match: `things/_thing\n` (trailing newline) and the new pattern matches `things/_thing`.

UPDATE: I added tests in #22.
