### PR TITLE
Don't try to process injected view cache dependencies as templates

### DIFF
--- a/lib/cache_digests/fragment_helper.rb
+++ b/lib/cache_digests/fragment_helper.rb
@@ -19,9 +19,7 @@ module CacheDigests
           (options && options.delete(:skip_digest))
 
         if !skip_digest
-          with_cache_prefix view_cache_dependencies do |dependencies|
-            super fragment_name_with_digest(key, dependencies), options, &block
-          end
+          super fragment_name_with_digest(key, view_cache_dependencies), options, &block
         else
           super
         end
@@ -29,25 +27,6 @@ module CacheDigests
 
       def explicitly_versioned_cache_key?(key)
         key.is_a?(Array) && key.first =~ /\Av\d+\Z/
-      end
-
-      # If view dependencies have been specified programmatically, we need
-      # to also set a new cache_prefix, so that the previously cached cache digest
-      # is not used. (Dependencies are not used to build the digest's cache key.)
-      def with_cache_prefix(dependencies)
-        if dependencies.any?
-          old_prefix = CacheDigests::TemplateDigestor.cache_prefix
-          new_prefix = dependencies.join('.')
-
-          begin
-            CacheDigests::TemplateDigestor.cache_prefix = new_prefix
-            yield dependencies
-          ensure
-            CacheDigests::TemplateDigestor.cache_prefix = old_prefix
-          end
-        else
-          yield dependencies
-        end
       end
   end
 end

--- a/test/template_digestor_test.rb
+++ b/test/template_digestor_test.rb
@@ -49,17 +49,17 @@ class TemplateDigestorTest < MiniTest::Unit::TestCase
   end
 
   def test_explicit_dependency_via_options
-    before = digest("messages/show")
-    after  = digest("messages/show", dependencies: ["arbitrary"])
-    assert before == after, "digest should have been cached, and not changed"
+    plain        = digest("messages/show")
+    fridge       = digest("messages/show", dependencies: ["fridge"])
+    phone        = digest("messages/show", dependencies: ["phone"])
+    fridge_phone = digest("messages/show", dependencies: ["fridge", "phone"])
 
-    CacheDigests::TemplateDigestor.cache_prefix = "1"
-    after  = digest("messages/show")
-    assert before == after, "digest should not have changed (no new dependencies)"
-
-    CacheDigests::TemplateDigestor.cache_prefix = "2"
-    after  = digest("messages/show", dependencies: ["arbitrary"])
-    assert before != after, "digest should have changed"
+    assert plain != fridge
+    assert plain != phone
+    assert plain != fridge_phone
+    assert fridge != phone
+    assert fridge != fridge_phone
+    assert phone != fridge_phone
   end
 
   def test_second_level_dependency


### PR DESCRIPTION
These injected dependencies should be included in the digest directly.

Also, we can get away with using the injected dependencies directly in the
digest cache key, rather than leaning on the cache_prefix. It's far
simpler.
