### PR TITLE
Digestor explicit dependency should not contain trailing whitespace (with tests)

### DIFF
--- a/lib/cache_digests/template_digestor.rb
+++ b/lib/cache_digests/template_digestor.rb
@@ -4,7 +4,7 @@ require 'logger'
 
 module CacheDigests
   class TemplateDigestor
-    EXPLICIT_DEPENDENCY = /# Template Dependency: ([^ ]+)/
+    EXPLICIT_DEPENDENCY = /# Template Dependency: (\S+)/
 
     # Matches:
     #   render partial: "comments/comment", collection: commentable.comments

--- a/test/fixtures/messages/show.html.erb
+++ b/test/fixtures/messages/show.html.erb
@@ -7,3 +7,7 @@
 <%= render @message.history.events %>
 
 <%# render "something_missing"  %>
+
+<%
+  # Template Dependency: messages/form
+%>

--- a/test/template_digestor_test.rb
+++ b/test/template_digestor_test.rb
@@ -48,6 +48,12 @@ class TemplateDigestorTest < MiniTest::Unit::TestCase
     end
   end
 
+  def test_explicit_dependency_in_multiline_erb_tag
+    assert_digest_difference("messages/show") do
+      change_template("messages/_form")
+    end
+  end
+
   def test_explicit_dependency_via_options
     plain        = digest("messages/show")
     fridge       = digest("messages/show", dependencies: ["fridge"])


### PR DESCRIPTION
See #21.
