### PR TITLE
#fragment_name_with_digest optional dependencies parameter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,16 @@
 PATH
   remote: .
   specs:
-    cache_digests (0.2.0)
+    cache_digests (0.3.0)
       actionpack (>= 3.2)
       thread_safe
 
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (3.2.12)
-      activemodel (= 3.2.12)
-      activesupport (= 3.2.12)
+    actionpack (3.2.13)
+      activemodel (= 3.2.13)
+      activesupport (= 3.2.13)
       builder (~> 3.0.0)
       erubis (~> 2.7.0)
       journey (~> 1.0.4)
@@ -18,26 +18,26 @@ GEM
       rack-cache (~> 1.2)
       rack-test (~> 0.6.1)
       sprockets (~> 2.2.1)
-    activemodel (3.2.12)
-      activesupport (= 3.2.12)
+    activemodel (3.2.13)
+      activesupport (= 3.2.13)
       builder (~> 3.0.0)
-    activesupport (3.2.12)
-      i18n (~> 0.6)
+    activesupport (3.2.13)
+      i18n (= 0.6.1)
       multi_json (~> 1.0)
-    atomic (1.0.1)
+    atomic (1.1.8)
     builder (3.0.4)
     erubis (2.7.0)
-    hike (1.2.1)
+    hike (1.2.2)
     i18n (0.6.1)
     journey (1.0.4)
-    minitest (2.12.1)
-    multi_json (1.6.1)
+    minitest (4.7.3)
+    multi_json (1.7.2)
     rack (1.4.5)
     rack-cache (1.2)
       rack (>= 0.4)
     rack-test (0.6.2)
       rack (>= 1.0)
-    rake (0.9.2.2)
+    rake (10.0.4)
     sprockets (2.2.2)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -45,7 +45,7 @@ GEM
       tilt (~> 1.1, != 1.3.0)
     thread_safe (0.1.0)
       atomic
-    tilt (1.3.3)
+    tilt (1.3.7)
 
 PLATFORMS
   ruby

--- a/lib/cache_digests/fragment_helper.rb
+++ b/lib/cache_digests/fragment_helper.rb
@@ -1,6 +1,6 @@
 module CacheDigests
   module FragmentHelper
-    def fragment_name_with_digest(name, dependencies)
+    def fragment_name_with_digest(name, dependencies=[])
       [*name, TemplateDigestor.digest(@virtual_path, formats.last.to_sym, lookup_context, dependencies: dependencies)]
     end
 

--- a/test/fragment_helper_test.rb
+++ b/test/fragment_helper_test.rb
@@ -58,12 +58,12 @@ class FragmentHelperTest < MiniTest::Unit::TestCase
   end
 
   def test_appends_the_key_with_digest
-    key_with_digest = fragmenter.fragment_name_with_digest("key", [])
+    key_with_digest = fragmenter.fragment_name_with_digest("key")
     assert_equal ['key', 'digest'], key_with_digest
   end
 
   def test_appends_the_array_key_with_digest
-    key_with_digest = fragmenter.fragment_name_with_digest(["key1", "key2"], [])
+    key_with_digest = fragmenter.fragment_name_with_digest(["key1", "key2"])
     assert_equal ['key1', 'key2', 'digest'], key_with_digest
   end
 


### PR DESCRIPTION
Fixes conflict with `jbuilder` and possibly other gems from: https://github.com/rails/cache_digests/commit/7ce6e7ee61740bb1c07914efc002871fcb93dc7a#L2R3
