### PR TITLE
Fix lookup of templates with specific formats

### DIFF
--- a/lib/cache_digests/template_digestor.rb
+++ b/lib/cache_digests/template_digestor.rb
@@ -60,7 +60,7 @@ module CacheDigests
       end
 
       def template
-        @template ||= finder.find(logical_name, [], partial?, formats: [ format ])
+        @template ||= finder.find(logical_name, [], partial?, [], formats: [ format ])
       end
 
       def dependency_digest

--- a/test/template_digestor_test.rb
+++ b/test/template_digestor_test.rb
@@ -21,7 +21,7 @@ class FixtureFinder
   FIXTURES_DIR = "#{File.dirname(__FILE__)}/fixtures"
   TMP_DIR      = "#{File.dirname(__FILE__)}/tmp"
   
-  def find(logical_name, keys, partial, options)
+  def find(logical_name, prefixes, partial, keys, options)
     FixtureTemplate.new("#{TMP_DIR}/#{partial ? logical_name.gsub(%r|/([^/]+)$|, '/_\1') : logical_name}.#{options[:formats].first}.erb")
   end
 end


### PR DESCRIPTION
Hi, I was playing around trying to use cache_digests to generate a checksum for a generated pdf (based on views with pdf as the format).

After much head-scratching I think I actually found a small bug in TemplateDigestor. There seems to be a missing argument in the call to ActionView::LookupContext which causes formats of templates to be ignored.

After this small change suddenly my digests started updating as I modified partial used by the pdf.
