### PR TITLE
Partials with numbers in the filename can be used as dependencies automatically

### DIFF
--- a/lib/cache_digests/dependency_tracker.rb
+++ b/lib/cache_digests/dependency_tracker.rb
@@ -39,7 +39,7 @@ module CacheDigests
         render\s*                     # render, followed by optional whitespace
         \(?                           # start an optional parenthesis for the render call
         (partial:|:partial\s+=>)?\s*  # naming the partial, used with collection -- 1st capture
-        ([@a-z"'][@a-z_\/\."']+)      # the template name itself -- 2nd capture
+        ([@a-z"'][@\w\/\."']+)        # the template name itself -- 2nd capture
       /x
 
       def self.call(name, template)
@@ -72,7 +72,7 @@ module CacheDigests
             # render(@topic)         => render("topics/topic")
             # render(topics)         => render("topics/topic")
             # render(message.topics) => render("topics/topic")
-            collect { |name| name.sub(/\A@?([a-z]+\.)*([a-z_]+)\z/) { "#{$2.pluralize}/#{$2.singularize}" } }.
+            collect { |name| name.sub(/\A@?([a-z]+\.)*([\w]+)\z/) { "#{$2.pluralize}/#{$2.singularize}" } }.
 
             # render("headline") => render("message/headline")
             collect { |name| name.include?("/") ? name : "#{directory}/#{name}" }.

--- a/test/dependency_tracker_test.rb
+++ b/test/dependency_tracker_test.rb
@@ -46,4 +46,12 @@ class DependencyTrackerTest < MiniTest::Unit::TestCase
     dependencies = tracker.find_dependencies("boo/hoo", template)
     assert_equal [], dependencies
   end
+
+  def test_dependency_of_erb_template_with_number_in_filename
+    tracker.register_tracker(:erb, CacheDigests::DependencyTracker::ERBTracker)
+    template = FakeTemplate.new("<%# render 'messages/message123' %>", :erb)
+    dependencies = tracker.find_dependencies("messages/message123", template)
+    assert_equal ["messages/message123"], dependencies
+    tracker.remove_tracker(:erb)
+  end
 end

--- a/test/fixtures/messages/show.html.erb
+++ b/test/fixtures/messages/show.html.erb
@@ -7,6 +7,7 @@
 <%= render @message.history.events %>
 
 <%# render "something_missing"  %>
+<%# render "message123" %>
 
 <%
   # Template Dependency: messages/form

--- a/test/template_digestor_test.rb
+++ b/test/template_digestor_test.rb
@@ -101,6 +101,12 @@ class TemplateDigestorTest < MiniTest::Unit::TestCase
     end
   end
 
+  def test_logging_of_missing_template_with_number_in_filename
+    assert_logged "Couldn't find template for digesting: messages/message123.html" do
+      digest("messages/show")
+    end
+  end
+
   def test_nested_template_directory
     assert_digest_difference("messages/show") do
       change_template("messages/actions/_move")


### PR DESCRIPTION
See rails/rails#10377

The regular expression would not match templates with numbers in the filename. For example:

``` ruby
<%= render 'shared/layout_1' %>
```

Would result in (in the log):

`Couldn't find template for digesting: shared/layout_.html`

... and the dependency would not be made.
