### PR TITLE
Mention using ERBTracker with HAML in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,12 +148,15 @@ Supported Templating Languages
 
 Only ERB is officially supported by the dependency tracker, but the ERB Tracker may work with other formats.
 
-Add this initializer to enable HAML support and check the results with `rake cache_digests:dependencies`
+Add this initializer to enable HAML or Slim support and check the results with `rake cache_digests:dependencies`
 
 ```ruby
 # config/initializers/cache_digests.rb
 
 # Enable experimental HAML support with the ERB Dependency Tracker
 CacheDigests::DependencyTracker.register_tracker :haml, CacheDigests::DependencyTracker::ERBTracker
+
+# Enable experimental Slim support with the ERB Dependency Tracker
+  CacheDigests::DependencyTracker.register_tracker :slim, CacheDigests::DependencyTracker::ERBTracker
 ```
 

--- a/README.md
+++ b/README.md
@@ -141,3 +141,19 @@ You'll need to use a special comment format to call those out:
 ```
 
 The pattern used to match these is `/# Template Dependency: ([^ ]+)/`, so it's important that you type it out just so. You can only declare one template dependency per line.
+
+
+Supported Templating Languages
+------------------------------
+
+Only ERB is officially supported by the dependency tracker, but the ERB Tracker may work with other formats.
+
+Add this initializer to enable HAML support and check the results with `rake cache_digests:dependencies`
+
+```ruby
+# config/initializers/cache_digests.rb
+
+# Enable experimental HAML support with the ERB Dependency Tracker
+CacheDigests::DependencyTracker.register_tracker :haml, CacheDigests::DependencyTracker::ERBTracker
+```
+


### PR DESCRIPTION
My templates are all in HAML and it took me a while to figure out why my dependencies weren't being recognized and how to fix it.

I added an initializer, as suggested by @tim-vandecasteele in #45

Hopeful this will make it more clear to others.
