### PR TITLE
Default to Cache::NullStore when ActionView::Base.cache_template_loading is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,6 @@ Our code from above can just look like:
 
 The caching key for app/views/projects/show.html.erb will be something like `views/projects/605816632-20120810191209/d9fb66b120b61f46707c67ab41d93cb2`. That last bit is a MD5 of the template file itself and all of its dependencies. It'll change if you change either the template or any of the dependencies, and thus allow the cache to expire automatically.
 
-Note that if your application cache is enabled, the template digest will not be recomputed until you restart your application and you will have to restart the app whenever you change template code.
-For development environment you might want to cache your fragments AND have dependent partials changes detected (with the penalty of recomputing the digests for each request). For that you can add `CacheDigests::TemplateDigestor.cache = ActiveSupport::Cache::NullStore.new` to your development configuration
-
 You can use these handy rake tasks to see how deep the rabbit hole goes:
 
 ```
@@ -91,6 +88,13 @@ $ rake cache_digests:nested_dependencies TEMPLATE=projects/show
 ]
 ```
 Note: this rake task doesn't differentiate between dependencies that are cached and dependencies that aren't - it is meant to show you all the dependencies of your view that cache_digests is able to derive.
+
+Recomputing digests after updating a template
+---------------------------------------------
+
+If your application's environment has caching enabled with `config.action_view.cache_template_loading` (e.g. production) then template digests are only computed once and saved until the application is restarted. Any updates to a template will require an application restart in order for the template source and digest changes to be reflected. If `config.action_view.cache_template_loading` is unset then it is set to the value of `config.cache_classes` by default.
+
+For environments that do not enable `config.action_view.cache_template_loading` (e.g. development) the default `CacheDigests::TemplateDigestor.cache` store is set to `ActiveSupport::Cache::NullStore.new`. This cache implementation doesn't actually store anything which forces template digests to recompute on every request. This is useful for cases where you want to test fragment caching (by enabling `config.action_controller.perform_caching`) or add template digests to your ETags with [rails/etagger](https://github.com/rails/etagger) but still allow templates and digests to reload any time a template is changed.
 
 Implicit dependencies
 ---------------------

--- a/lib/cache_digests/engine.rb
+++ b/lib/cache_digests/engine.rb
@@ -5,6 +5,9 @@ module CacheDigests
 
       ActiveSupport.on_load :action_view do
         ActionView::Base.send :include, CacheDigests::FragmentHelper
+        unless ActionView::Base.cache_template_loading
+          CacheDigests::TemplateDigestor.cache = ActiveSupport::Cache::NullStore.new
+        end
       end
 
       ActiveSupport.on_load :action_controller do


### PR DESCRIPTION
I was a little confused about the digest caching behavior like the people discussing issues: rails/cache_digests#11, rails/cache_digests#13, and rails/cache_digests#24.

For my specific use case, I started using `fresh_when` calls but noticed that requests did not refresh when I made changes to templates and always returned `304` responses. I came across this [HackerNews post by jeremykemper](https://news.ycombinator.com/item?id=4874600) where he suggested using [rails/etagger](https://github.com/rails/etagger) to add the current action's template digest as a declarative ETag e.g.

``` ruby
etag do
  CacheDigests::TemplateDigestor.digest [controller_name, action_name].join('/'),
    request.format.symbol,
    lookup_context,
    dependencies: view_cache_dependencies
end
```

This works great in development but requires `ActiveSupport::Cache::NullStore` to be used like the previous issues stated. This pull request simply updates the `CacheDigests::Engine` and sets `CacheDigests::TemplateDigestor.cache` to `NullStore` if `ActionView::Base.cache_template_loading` is disabled.
