### PR TITLE
Fix issue with not matching renders when using an underscore

### DIFF
--- a/lib/cache_digests/dependency_tracker.rb
+++ b/lib/cache_digests/dependency_tracker.rb
@@ -72,7 +72,8 @@ module CacheDigests
             # render(@topic)         => render("topics/topic")
             # render(topics)         => render("topics/topic")
             # render(message.topics) => render("topics/topic")
-            collect { |name| name.sub(/\A@?([a-z]+\.)*([\w]+)\z/) { "#{$2.pluralize}/#{$2.singularize}" } }.
+            # render(message.topic)  => render("topics/topic")
+            collect { |name| name.sub(/\A@?([a-z_]+\.)*([\w]+)\z/) { "#{$2.pluralize}/#{$2.singularize}" } }.
 
             # render("headline") => render("message/headline")
             collect { |name| name.include?("/") ? name : "#{directory}/#{name}" }.


### PR DESCRIPTION
This fixes #50. The regex being used to match render calls was incorrectly not matching against variables with underscores in the name and so it was using the wrong regex match data to populate the template dependency. Because underscore is a valid character for a variable, this fixes the ERBTracker to match it properly.

This is the gist of the change:

``` ruby
# Before:
render feed_status.user # => Dependency: 'feed_statuses/feed_status.users'

# After:
render feed_status.user # => Dependency: 'users/user'
```

Failing test included.
