### PR TITLE
Take the lookup details into consideration

### DIFF
--- a/lib/cache_digests/template_digestor.rb
+++ b/lib/cache_digests/template_digestor.rb
@@ -11,7 +11,8 @@ module CacheDigests
     cattr_accessor(:logger, instance_reader: true)
 
     def self.digest(name, format, finder, options = {})
-      cache_key = [ "digestor", cache_prefix, name, format, *Array.wrap(options[:dependencies]) ].compact.join("/")
+      details_key = finder.details_key.hash
+      cache_key = [ "digestor", cache_prefix, name, details_key, format, *Array.wrap(options[:dependencies]) ].compact.join("/")
       cache.fetch(cache_key) do
         cache.write(cache_key, nil) # Prevent re-entry
         new(name, format, finder, options).digest


### PR DESCRIPTION
This makes the cache key generation respect changes in the details key, allowing for different templates with the same virtual path to coexist.

I hit a bug where two templates being treated as one, causing rendering bugs in production. I discovered that it was due Cache Digests – the digest remained the same even if the details were different.

I'm using details like this:

``` ruby
module MobileViewResolution
  ActionView::LookupContext.register_detail(:devices) { [] }

  extend ActiveSupport::Concern

  included do
    path = Rails.root.join("app", "views")
    pattern = ":prefix/:action{.:devices,}{.:formats,}{.:handlers,}"
    resolver = ActionView::FileSystemResolver.new(path, pattern)
    prepend_view_path(resolver)
  end

  private

  def details_for_lookup
    if mobile_request?
      devices = ["mobile"]
    else
      devices = []
    end

    super.merge(devices: devices)
  end
end
```

I've tried running my app with this branch and it solved the issue.
