### PR TITLE
Fix README example typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Russian-doll caching schemes are hard to maintain when nested templates are upda
 <% cache [ "v1", todolist ] do %>
   My todolist: <%= todolist.name %>
 
-  <%= render document.comments %>
+  <%= render todolist.comments %>
 <% end %>
 
 # app/views/comments/_comment.html.erb


### PR DESCRIPTION
I'm assuming this was supposed to be `todolist`.  If not, disregard.
