### PR TITLE
Log digest as :debug instead of :info

### DIFF
--- a/lib/cache_digests/template_digestor.rb
+++ b/lib/cache_digests/template_digestor.rb
@@ -26,7 +26,7 @@ module CacheDigests
 
     def digest
       Digest::MD5.hexdigest("#{source}-#{dependency_digest}").tap do |digest|
-        logger.try :info, "Cache digest for #{name}.#{format}: #{digest}"
+        logger.try :debug, "Cache digest for #{name}.#{format}: #{digest}"
       end
     rescue ActionView::MissingTemplate
       logger.try :error, "Couldn't find template for digesting: #{name}.#{format}"


### PR DESCRIPTION
I think it would be more appropriate to log digest entries as :debug. It is currently logging way too much data in our production logs.
